### PR TITLE
Fix "absolute path" error on some systems

### DIFF
--- a/systemd/listenssh.service
+++ b/systemd/listenssh.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 WorkingDirectory=/root/Listenssh
-ExecStart=python3 main.py
+ExecStart=/usr/bin/python3 main.py
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
Sometimes systemd wants an absolute path for python instead of just running the usual `python3` command.
Fixed by replacing it by `/usr/bin/python` which seems to be the default for many Modern Linux distros